### PR TITLE
cache verda build artifacts between ci runs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -100,7 +100,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore verda cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .verda-cache
           key: verda-${{ hashFiles('VERSION') }}-${{ hashFiles('private-build-plans.toml') }}
@@ -113,7 +113,7 @@ jobs:
           VERDA_CACHE: .verda-cache
         run: ./build.sh
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: font-build
           path: _output/${{ env.FONT_NAME }}-*.zip
@@ -124,7 +124,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: font-build
           path: _output
@@ -165,13 +165,13 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: failure()
         with:
           name: visual-diffs
           path: _diffs/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: failure()
         with:
           name: visual-generated
@@ -192,7 +192,7 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Download font artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: font-build
           path: _output

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -113,7 +113,7 @@ jobs:
           VERDA_CACHE: .verda-cache
         run: ./build.sh
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: font-build
           path: _output/${{ env.FONT_NAME }}-*.zip
@@ -124,7 +124,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: font-build
           path: _output
@@ -165,13 +165,13 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: visual-diffs
           path: _diffs/
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: visual-generated
@@ -192,7 +192,7 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Download font artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: font-build
           path: _output

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,9 +99,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Restore verda cache
+        uses: actions/cache@v4
+        with:
+          path: .verda-cache
+          key: verda-${{ hashFiles('VERSION') }}-${{ hashFiles('private-build-plans.toml') }}
+          restore-keys: |
+            verda-${{ hashFiles('VERSION') }}-
+
       - name: Build font
         env:
           IMAGE_REF: ${{ needs.build-image.outputs.image-ref }}
+          VERDA_CACHE: .verda-cache
         run: ./build.sh
 
       - uses: actions/upload-artifact@v4

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ BUILD_PLAN=${BUILD_PLAN:-private-build-plans.toml}
 OUTPUT_DIR=$(pwd)/_output
 IMAGE=${IMAGE:-ghcr.io/awnion/custom-iosevka-nerd-font}
 IMAGE_REF=${IMAGE_REF:-}
+VERDA_CACHE=${VERDA_CACHE:-}
 
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
@@ -34,9 +35,18 @@ fi
 
 echo "Building font '$FONT_NAME' using plan '$BUILD_PLAN' ..."
 
+CACHE_MOUNT=()
+if [ -n "$VERDA_CACHE" ]; then
+    mkdir -p "$VERDA_CACHE"
+    VERDA_CACHE=$(cd "$VERDA_CACHE" && pwd)
+    echo "Using verda cache: $VERDA_CACHE"
+    CACHE_MOUNT=(-v "$VERDA_CACHE":${BUILD_DIR}/iosevka/.build)
+fi
+
 docker run --rm -t \
     -v "$OUTPUT_DIR":/output \
     -v "$(pwd)/$BUILD_PLAN":${BUILD_DIR}/iosevka/private-build-plans.toml:ro \
+    "${CACHE_MOUNT[@]}" \
     "$IMAGE_REF" -c "\
         cd ${BUILD_DIR}/iosevka && \
         bun run build -- ttf::${FONT_NAME} && \


### PR DESCRIPTION
- Cache verda `.build/` directory between CI runs using `actions/cache`
- Mount cached directory into the Docker container during font build
- Cache key based on Iosevka version + build plan hash (verda uses SHA-1 file hashing, not timestamps, so restored cache is valid)
- On cache hit, verda skips unchanged build targets